### PR TITLE
Fixes issue where picker.range has not been set

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@
     var currentIndex = e.data.index;
     var days = picker.picker.find('.day');
     var currentDate;
+    if (!picker.range) {
+      return;
+    }
     var range = picker.range.slice(0);
     var selected = picker.range.slice(0); // clone
 


### PR DESCRIPTION
Initial mouseenter events on the picker causes an exception to be raised, due to picker.range being undefined.

Returning if it hasn't been set doesn't seem to break anything, and prevents the errors from being thrown.